### PR TITLE
Incorrect stats when zero deaths

### DIFF
--- a/lib/services/statsService.js
+++ b/lib/services/statsService.js
@@ -129,7 +129,8 @@ var getStatSummary = function(options) {
 		// - average KDA ratio
 
 		let matchCounter = 0;
-		let kdaSum = 0;
+		let kaSum = 0;
+		let dSum = 0;
 
 		const lblTopKda = 'Top KDA';
 		const lblTopK = 'Top Kills';
@@ -154,7 +155,7 @@ var getStatSummary = function(options) {
 			const kills = m.players.kills;
 			const deaths = m.players.deaths;
 			const assists = m.players.assists;
-			const kda = (kills + assists) / deaths;
+			const kda = (kills + assists) / (deaths > 1 ? deaths : 1);
 
 			if (kda > topStats[lblTopKda].value) {
 				topStats[lblTopKda].value = kda;
@@ -191,13 +192,14 @@ var getStatSummary = function(options) {
 				topStats[lblTopXpm].displayValue = m.players.xpPerMin.toFixed(2);
 				topStats[lblTopXpm].match = matchId;
 			}
-			kdaSum += kda;
+			kaSum += kills + assists;
+			dSum += deaths;
 			++matchCounter;
 		});
 
 		topStats[lblAvgKda] = {
-			value: kdaSum / matchCounter,
-			displayValue: (kdaSum / matchCounter).toFixed(2)
+			value: kaSum / dSum,
+			displayValue: (kaSum / dSum).toFixed(2)
 		};
 
 		return topStats;


### PR DESCRIPTION
Fixed kda calc when zero deaths (defaulted to 1). Changed avg kda to use sum of ka / sum of deaths
